### PR TITLE
Corrige mimetype do get datasets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ _mailinglist
 .pytest_cache/
 .idea/
 docs/_build/
+.vscode
 
 # Coverage reports
 htmlcov/

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "edf6c7ae620524da136ca55bc15014ce128a26dba4b3d75851e0652825bfc7d3"
+            "sha256": "dc16a239f8f9ec986c07cbc45e9c5896c1c45f0cf886efe1e6217b83fb7f4177"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -78,12 +78,20 @@
             ],
             "version": "==1.1.1"
         },
+        "marshmallow": {
+            "hashes": [
+                "sha256:159c3ed37094d66867bbacdf2e7effd7c7ad88c6b11f9b398ff5ea1d118508c3",
+                "sha256:51188df086da5c427c3c193faddf7f95857ee4053dbf2d083e5cbfd846b2fb29"
+            ],
+            "index": "pypi",
+            "version": "==3.0.3"
+        },
         "werkzeug": {
             "hashes": [
-                "sha256:87ae4e5b5366da2347eb3116c0e6c681a0e939a33b2805e2c0cbd282664932c4",
-                "sha256:a13b74dd3c45f758d4ebdb224be8f1ab8ef58b3c0ffc1783a8c7d9f4f50227e6"
+                "sha256:00d32beac38fcd48d329566f80d39f10ec2ed994efbecfb8dd4b320062d05902",
+                "sha256:0a24d43be6a7dce81bae05292356176d6c46d63e42a0dd3f9504b210a9cfaa43"
             ],
-            "version": "==0.15.5"
+            "version": "==0.15.6"
         }
     },
     "develop": {

--- a/laguinho/routes/datasets.py
+++ b/laguinho/routes/datasets.py
@@ -9,8 +9,8 @@ datasets_metadata = []
 def publish():
     result = dataset_metadata.load(request.json, unknown=EXCLUDE)
     datasets_metadata.append(result)
-    return result, 201
+    return jsonify(result), 201
 
 @datasets.route("/datasets", methods=['GET'])
 def get_datasets():
-    return dataset_metadata.dumps(datasets_metadata, many=True)
+    return jsonify(datasets_metadata)


### PR DESCRIPTION
No PR #45 acabou passando despercebido que o `GET /datasets` estava retornando um JSON mas com o mimetype `plain/text`. Eu havia sugerido a edição do retorno do `get_datasets` pra usar o schema marshmallow pra gerar o JSON, ao invés do `jsonify` do flask, porém eu havia esquecido que o jsonify adiciona automaticamente o mimetype como `application/json` e o schema não... daí pra resolver isso eu podia escolher entre, adicionar o mimetype na mão, instalar a extensão [flask-marshmallow](https://flask-marshmallow.readthedocs.io/en/latest/) que já tem um jsonify embutido no dump, ou simplesmente usar o jsonify em tudo... Escolhi a terceira opção pois é a mais simples e não precisa adicionar nenhuma nova dependencia.

Sugiro também que todos os outros endpoints usem como retorno o jsonify pra padronizarmos (Esse PR também resolve isso, afinal só temos dois endpoints msm kkkkkkkkk)