### PR TITLE
Adiciona checagem de dataset duplicado

### DIFF
--- a/laguinho/routes/datasets.py
+++ b/laguinho/routes/datasets.py
@@ -5,9 +5,20 @@ from marshmallow import ValidationError, EXCLUDE
 datasets = Blueprint('datasets', __name__)
 datasets_metadata = []
 
+def equals(dataset1, dataset2):
+    return (dataset1['url'] == dataset2['url'] and
+            dataset1['path'] == dataset2['path'])
+
+def dataset_exists(incoming_dataset):
+    compare_datasets = lambda dataset: equals(dataset, incoming_dataset)
+    filtered = list(filter(compare_datasets, datasets_metadata))
+    return len(filtered) > 0
+
 @datasets.route("/datasets", methods=['POST'], strict_slashes=False)
 def publish():
     result = dataset_metadata.load(request.json, unknown=EXCLUDE)
+    if dataset_exists(result):
+        return jsonify('Dataset already exists'), 409
     datasets_metadata.append(result)
     return jsonify(result), 201
 

--- a/laguinho/routes/datasets.py
+++ b/laguinho/routes/datasets.py
@@ -6,7 +6,8 @@ datasets = Blueprint('datasets', __name__)
 datasets_metadata = []
 
 def equals(dataset1, dataset2):
-    return (dataset1['url'] == dataset2['url'] and
+    return (dataset1['name'] == dataset2['name'] or
+            dataset1['url'] == dataset2['url'] and
             dataset1['path'] == dataset2['path'])
 
 def dataset_exists(incoming_dataset):


### PR DESCRIPTION
Fixes #47.

Algumas considerações de antemão:

Criei algumas funções utilitárias para deixar o código mais legível, mas acho que elas não deveriam estar no arquivo `/routes/datasets.py` :thinking: Mas não sei onde ficaria mais adequado também.

Fiquei pensando também se alguém poderia servir arquivos que estão no mesmo diretório, mas tem extensões diferentes (jsons e csvs). Imagino que não deveríamos dar suporte a isso, para não promover desorganização, mas foi uma dúvida que surgiu.