### PR TITLE
Adiciona docker-compose com mongodb e passos de configuração no README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ _mailinglist
 .idea/
 docs/_build/
 .vscode
+.mongo
 
 # Coverage reports
 htmlcov/

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Os dados são abertos e todos podem contribuir com mais dados e endpoints. Veja 
 
 Este projeto é feito utilizando [Python 3](https://www.python.org/), você precisa tê-lo [instalado](https://www.python.org/downloads/) na sua máquina.
 
-Para rodarmos as dependências de banco de dados e servidores externos, utilizamos Docker e Docker Compose, caso ainda náo tenha instalado na sua máquina, [esse tutorial](https://docs.docker.com/install/) ajuda a instalar o docker e [esse tutorial](https://docs.docker.com/compose/install/) ajuda a instalar o docker-compose, mas lembre-se que qualquer dúvida no processo de instalação, sempre tem algúem no [discord](https://discord.gg/vMcuNtt) pra ajudar!
+Para rodarmos as dependências de banco de dados e servidores externos, utilizamos Docker e Docker Compose, caso ainda não tenha instalado na sua máquina, [esse tutorial](https://docs.docker.com/install/) ajuda a instalar o docker e [esse tutorial](https://docs.docker.com/compose/install/) ajuda a instalar o docker-compose, mas lembre-se que qualquer dúvida no processo de instalação, sempre tem alguém no [discord](https://discord.gg/vMcuNtt) pra ajudar!
 
 ### Configurando a máquina
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,20 @@ Os dados são abertos e todos podem contribuir com mais dados e endpoints. Veja 
 
 Este projeto é feito utilizando [Python 3](https://www.python.org/), você precisa tê-lo [instalado](https://www.python.org/downloads/) na sua máquina.
 
+Para rodarmos as dependências de banco de dados e servidores externos, utilizamos Docker e Docker Compose, caso ainda náo tenha instalado na sua máquina, [esse tutorial](https://docs.docker.com/install/) ajuda a instalar o docker e [esse tutorial](https://docs.docker.com/compose/install/) ajuda a instalar o docker-compose, mas lembre-se que qualquer dúvida no processo de instalação, sempre tem algúem no [discord](https://discord.gg/vMcuNtt) pra ajudar!
+
 ### Configurando a máquina
+
+Antes de tudo, você precisa rodar as dependências com o `docker-compose` pra isso, rode o comando abaixo:
+
+``` bash
+# Roda banco de dados e outras dependências
+$ docker-compose up
+```
+
+Isso iniciará as dependencias e vai ficar mostrando uns logs no terminal...
+
+Após iniciado, você deve, **em outro terminal**, rodar os comandos abaixo
 
 ``` bash
 # instalando o pipenv

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+version: '3'
+
+services:
+  mongo-express:
+    image: mongo-express
+    restart: always
+    environment:
+      ME_CONFIG_BASICAUTH_USERNAME: opendevufcg
+      ME_CONFIG_BASICAUTH_PASSWORD: laguinhoapi
+      ME_CONFIG_MONGODB_PORT: 27017
+      ME_CONFIG_MONGODB_ADMINUSERNAME: opendevufcg
+      ME_CONFIG_MONGODB_ADMINPASSWORD: laguinhoapi
+    ports:
+      - 8081:8081
+    links:
+      - mongodb:mongo
+    networks:
+      - mongo-network
+
+  mongodb:
+    image: mongo
+    restart: always
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: opendevufcg
+      MONGO_INITDB_ROOT_PASSWORD: laguinhoapi
+    ports:
+      - "27017:27017"
+    volumes:
+      - ./.mongo/data/db:/data/db
+    networks:
+      - mongo-network
+
+networks: 
+  mongo-network:
+    driver: bridge


### PR DESCRIPTION
Configura um docker-compose contendo o mongodb e o mongo-express para gerenciamento numa interface web.

O mongo foi configurado com:
- username: opendevufcg
- senha: laguinhoapi
- porta: 27017

O mongo-express foi configurado com:
- username: opendevufcg
- senha: laguinhoapi
- porta: 8081

Para testar esse PR, basta rodar os passos descritos na alteração do README, ao executar o docker-compose, deve ser possível acessar o `localhost:8081` com as credenciais que citei acima

<!-- INSTRUÇÕES: -->

<!-- 1. Seja descritivo no nome de sua PR. -->

<!-- 2. Informe o número da issue a que sua PR se refere (usando #NUMERO_DA_ISSUE). -->

<!-- 3. Nos conte mais sobre sua PR e o que você fez! (: -->

<!-- 4. Garanta que sua contribuição esteja de acordo com as regras descritas nos links abaixo. -->

- [X] Minha contribuição respeita o [código de conduta](../CODE_OF_CONDUCT.md) do repositório.
