### PR TITLE
Use mongo projection to remove _id from responses

### DIFF
--- a/laguinho/routes/datasets.py
+++ b/laguinho/routes/datasets.py
@@ -29,11 +29,11 @@ def publish():
 
 @datasets.route("/datasets", methods=['GET'], strict_slashes=False)
 def get_datasets():
-    dsets = list(datasets_metadata.find({}, {'_id': 0}))
+    dsets = list(datasets_metadata.find({}, projection={'_id': False}))
     return jsonify(dsets)
 
 
 @datasets.route("/datasets/<name>", methods=['GET'], strict_slashes=False)
 def get_datasets_by_name(name):
-    search_result = datasets_metadata.find_one_or_404({'name': name}, {'_id': 0})
+    search_result = datasets_metadata.find_one_or_404({'name': name},  projection={'_id': False})
     return jsonify(search_result), 200

--- a/laguinho/routes/datasets.py
+++ b/laguinho/routes/datasets.py
@@ -23,22 +23,17 @@ def publish():
     result = dataset_metadata.load(request.json, unknown=EXCLUDE)
     if dataset_exists(result):
         return jsonify('Dataset already exists'), 409
-    datasets_metadata.insert_one(result)
-    del result['_id']
+    datasets_metadata.insert_one(result.copy())
     return jsonify(result), 201
 
 
 @datasets.route("/datasets", methods=['GET'], strict_slashes=False)
 def get_datasets():
-    dsets = list(datasets_metadata.find())
-    for ds in dsets:
-        del ds['_id']
-
+    dsets = list(datasets_metadata.find({}, {'_id': 0}))
     return jsonify(dsets)
 
 
 @datasets.route("/datasets/<name>", methods=['GET'], strict_slashes=False)
 def get_datasets_by_name(name):
-    search_result = datasets_metadata.find_one_or_404({'name': name})
-    del search_result['_id']
+    search_result = datasets_metadata.find_one_or_404({'name': name}, {'_id': 0})
     return jsonify(search_result), 200


### PR DESCRIPTION
### Enhancement proposal for issue #69 

Mongo allow us to select the fields we're retreiving by providing a second argument (projection).

So I added the projection **{_id: 0}** to prevent that field to appear in responses instead of deleting it from the response.

One interesting thing is that the insert_one method from PyMongo was modifying the input we were providing, so I prevent this mutation by providing a copy of the result dictionary.

Hope it helps!
